### PR TITLE
Updated catalog-info.yaml to no longer use visibility and to add system

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,4 +25,4 @@ spec:
   type: library
   lifecycle: production
   owner: boozallen/zdf-maintainers
-  visibility: public
+  system: system:default/salesforce-platform-system


### PR DESCRIPTION
This PR updates the catalog-info.yaml file for this component in the Booz Allen Developer Portal to include the new salesforce-platform-system and removes spec.visibility:public to be in line with the new way of managing public entities in the Developer Portal. More information can be found in the docs: https://developerportal.bah.com/docs/default/component/developer-portal-user-guide/how-to/tenants/manage-public-entities/manage-public-entities/

Created this as a draft because this should not be merged until the tenant and system are registered in the Developer Portal, and until the changes are made on tomorrow, Jan 31st in the Developer Portal.